### PR TITLE
Actually fix shortcuts activating incorrectly when labeling

### DIFF
--- a/source/NIVPLUS_CHANGES.TXT
+++ b/source/NIVPLUS_CHANGES.TXT
@@ -55,7 +55,6 @@ ADD: Bundled 'help.com' module again
 Release 2.1:
 NOTE: I didn't update this package with the new starmap and guide for almost 2 months. So the occasion of finally updating the archive, made me feel I had to fix these little bugs. April, 2009 starmap update has been incorporated.
 FIX: DL module has been updated. It now correctly shows the number of notes of the main object, if queried about a planet (previously it still showed the # of notes of the star).
-FIX: 's' and 'p' don't activate their respective functions when labeling, anymore.
 
 Release 2.2:
 FIX: Epoc 6012's triad sinister was calculated incorrectly and started with a '1'.
@@ -68,4 +67,5 @@ FIX: Fixed bug that caused r2.2 to not run correctly under Windows due to a stup
 Release 2.3:
 ADD: 'Tab' key in the Stardrifter now toggles 'anti aliasing' on and off.
 ADD: 'F1' now shows an about/help page with keyboard shortcuts
+FIX: 's' and 'p' don't activate their respective functions when labeling, anymore.
 UPDATED manuals.

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -4088,7 +4088,7 @@ void main ()
 						status("NO FLASH", 100);
 					}
 				}
-				if (c=='s')
+				if (c=='s' && !(labstar || labplanet))
 				{
 					if (roofspeed)
 					{
@@ -4103,7 +4103,7 @@ void main ()
 					
 				}
 				// Added a pause feature when filming a movie (neuzd)
-				if (c == 'p')
+				if (c == 'p' && !(labstar || labplanet))
 				{
 					if (movie)
 					{


### PR DESCRIPTION
FIX: 's' and 'p' don't activate their respective functions when labeling, anymore.