### PR TITLE
Add DOSBox-X config and launcher script for modern Windows systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ movies/*
 source/BIN/*
 
 *.zip
+/bin

--- a/Launch.bat
+++ b/Launch.bat
@@ -1,0 +1,47 @@
+@echo off
+
+set PORTABLE=0
+
+
+
+
+
+set SCRIPT_DIR=%~dp0
+set SCRIPT_DIR=%SCRIPT_DIR:~0,-1%
+
+if "%PORTABLE%"=="1" (
+    set DOSBOX_X_BIN=%SCRIPT_DIR%\bin\x64\Release\dosbox-x.exe
+) else (
+    set DOSBOX_X_BIN=C:\DOSBox-X\dosbox-x.exe
+)
+
+set CONF_FILE=%SCRIPT_DIR%\dosbox.conf
+set MOUNT_DIR=%SCRIPT_DIR%
+
+echo.
+echo +-------------------------+
+echo ^| Noctis IV Plus Launcher ^|
+echo +-------------------------+
+echo.
+
+if "%PORTABLE%"=="1" (
+    echo Using portable binary: "%DOSBOX_X_BIN%"
+) else (
+    echo Using installed binary: "%DOSBOX_X_BIN%"
+)
+
+if not exist "%DOSBOX_X_BIN%" (
+    echo.
+    echo DOSBox-X binary is not installed!
+    echo Download DOSBox-X here: https://github.com/joncampbell123/dosbox-x/releases/latest
+    echo.
+    <nul set /p "=Press any key to exit . . . "
+    pause >nul
+    exit /b
+)
+
+echo Using conf file: "%CONF_FILE%"
+
+
+
+"%DOSBOX_X_BIN%" -c "mount c '%MOUNT_DIR%'" -c "c:" -c "cd modules" -c "NOCTIS.EXE" -conf "%CONF_FILE%" -exit

--- a/Launch.bat
+++ b/Launch.bat
@@ -1,43 +1,48 @@
 @echo off
 
-set PORTABLE=0
-
-
-
-
-
 set SCRIPT_DIR=%~dp0
 set SCRIPT_DIR=%SCRIPT_DIR:~0,-1%
 
-if "%PORTABLE%"=="1" (
-    set DOSBOX_X_BIN=%SCRIPT_DIR%\bin\x64\Release\dosbox-x.exe
+set DBX_BIN_INSTALLED=C:\DOSBox-X\dosbox-x.exe
+set DBX_BIN_PORTABLE=%SCRIPT_DIR%\bin\x64\Release\dosbox-x.exe
+
+echo.
+echo ^+------------------------------^+
+echo ^| Noctis IV / IV Plus Launcher ^|
+echo ^+------------------------------^+
+echo.
+
+if exist "%DBX_BIN_INSTALLED%" (
+    echo DOSBox-X installation found!
+    set PORTABLE=0
+    set DOSBOX_X_BIN=%DBX_BIN_INSTALLED%
 ) else (
-    set DOSBOX_X_BIN=C:\DOSBox-X\dosbox-x.exe
+    echo DOSBox-X is not installed! Looking for portable version...
+    if exist "%DBX_BIN_PORTABLE%" (
+        echo Portable DOSBox-X found!
+        set PORTABLE=1
+        set DOSBOX_X_BIN=%DBX_BIN_PORTABLE%
+    ) else (
+        echo Could not find portable DOSBox-X!
+        echo.
+        echo ERROR: No DOSBox-X binary found! Unable to launch!
+        echo Download DOSBox-X here: https://github.com/joncampbell123/dosbox-x/releases/latest
+        echo.
+        <nul set /p "=Press any key to exit . . . "
+        pause >nul
+        exit /b
+    )
 )
+
+echo.
 
 set CONF_FILE=%SCRIPT_DIR%\dosbox.conf
 set MOUNT_DIR=%SCRIPT_DIR%
-
-echo.
-echo +-------------------------+
-echo ^| Noctis IV Plus Launcher ^|
-echo +-------------------------+
-echo.
 
 if "%PORTABLE%"=="1" (
     echo Using portable binary: "%DOSBOX_X_BIN%"
 ) else (
     echo Using installed binary: "%DOSBOX_X_BIN%"
-)
-
-if not exist "%DOSBOX_X_BIN%" (
-    echo.
-    echo DOSBox-X binary is not installed!
-    echo Download DOSBox-X here: https://github.com/joncampbell123/dosbox-x/releases/latest
-    echo.
-    <nul set /p "=Press any key to exit . . . "
-    pause >nul
-    exit /b
 )
 
 echo Using conf file: "%CONF_FILE%"

--- a/Launch.bat
+++ b/Launch.bat
@@ -6,6 +6,9 @@ set SCRIPT_DIR=%SCRIPT_DIR:~0,-1%
 set DBX_BIN_INSTALLED=C:\DOSBox-X\dosbox-x.exe
 set DBX_BIN_PORTABLE=%SCRIPT_DIR%\bin\x64\Release\dosbox-x.exe
 
+set CONF_FILE=%SCRIPT_DIR%\dosbox.conf
+set MOUNT_DIR=%SCRIPT_DIR%
+
 echo.
 echo ^+------------------------------^+
 echo ^| Noctis IV / IV Plus Launcher ^|
@@ -26,7 +29,7 @@ if exist "%DBX_BIN_INSTALLED%" (
         echo Could not find portable DOSBox-X!
         echo.
         echo ERROR: No DOSBox-X binary found! Unable to launch!
-        echo Download DOSBox-X here: https://github.com/joncampbell123/dosbox-x/releases/latest
+        echo Download DOSBox-X from here: https://github.com/joncampbell123/dosbox-x/releases/latest
         echo.
         <nul set /p "=Press any key to exit . . . "
         pause >nul
@@ -36,16 +39,35 @@ if exist "%DBX_BIN_INSTALLED%" (
 
 echo.
 
-set CONF_FILE=%SCRIPT_DIR%\dosbox.conf
-set MOUNT_DIR=%SCRIPT_DIR%
-
 if "%PORTABLE%"=="1" (
     echo Using portable binary: "%DOSBOX_X_BIN%"
 ) else (
     echo Using installed binary: "%DOSBOX_X_BIN%"
 )
 
-echo Using conf file: "%CONF_FILE%"
+if exist "%CONF_FILE%" (
+    echo Using conf file: "%CONF_FILE%"
+) else (
+    echo Could not find conf file: "%CONF_FILE%"
+    echo.
+    echo ERROR: Configuration file not found! Unable to launch!
+    echo Download here: https://github.com/jorisvddonk/Noctis-IV-Plus/raw/refs/heads/master/dosbox.conf
+    echo.
+    <nul set /p "=Press any key to exit . . . "
+    pause >nul
+    exit /b
+)
+
+if not exist "%MOUNT_DIR%\modules\NOCTIS.EXE" (
+    echo.
+    echo ERROR: Noctis IV / IV Plus not found! Unable to launch!
+    echo Download Noctis IV here: https://80.style/packs/zip/hsp/noctis_iv-noctis_iv_download_JmsLdos_onlyK
+    echo Download Noctis IV Plus from here: https://github.com/jorisvddonk/Noctis-IV-Plus/releases/latest
+    echo.
+    <nul set /p "=Press any key to exit . . . "
+    pause >nul
+    exit /b
+)
 
 
 

--- a/Launch.bat
+++ b/Launch.bat
@@ -71,4 +71,4 @@ if not exist "%MOUNT_DIR%\modules\NOCTIS.EXE" (
 
 
 
-"%DOSBOX_X_BIN%" -c "mount c '%MOUNT_DIR%'" -c "c:" -c "cd modules" -c "NOCTIS.EXE" -conf "%CONF_FILE%" -exit
+"%DOSBOX_X_BIN%" -c "mount n '%MOUNT_DIR%'" -c "n:" -c "cd modules" -c "NOCTIS.EXE" -conf "%CONF_FILE%" -exit

--- a/README.md
+++ b/README.md
@@ -12,14 +12,22 @@ For the manual, see [manual/noctis_iv_manual.html](manual/noctis_iv_manual.html)
 
 Noctis IV was made for MS-DOS and early Windows versions that still supported 16-bit MS-DOS executables natively, and as such, you'll need to be able to run DOS on your computer. To run Noctis IV plus on modern computers, you have three main options, in order of simplest to most complicated to setup:
 
-1. [DosBOS-X](https://dosbox-x.com/) (all modern operating systems)
+1. [DOSBox-X](https://dosbox-x.com/) (all modern operating systems)
 2. [DOSEMU](http://www.dosemu.org/) (Linux only)
 3. A [FreeDOS](https://www.freedos.org/) or MS-DOS environment running inside of a virtual machine like [VirtualBox](https://www.virtualbox.org/)
 
-The author of Noctis IV Plus recommends DosBOS-X, using the "dynamic_x86" CPU core, simulating a Pentium III 866MHz EB (~407000 cycles). Note that with this setup, a completely empty Stardrifter floating in space may actually give you *lower* frames per second than one that's orbiting a planet in a star system. You may want to play around with the cycle count a bit to find the right number for your computer.
+### DOSBox-X (recommended)
 
-Once you've got an MS-DOS setup running, simply run the following from within the MS-DOS environment:
+The `Launch.bat` script lets you run Noctis IV Plus with a simple double-click on Windows systems. It expects DOSBox-X to either be installed in it's default location `C:\DOSBox-X\dosbox-x.exe`, or installed portably with it's `bin` folder placed in the main `Noctis-IV-Plus` folder.
 
+If you are using a system other than Windows, simply run the following command:
+```
+dosbox-x -c "mount n '<directory where NIVPlus is installed>'" -c "n:" -c "cd modules" -c "NOCTIS.EXE" -conf dosbox.conf -exit
+```
+
+### Other DOS Emulators
+
+Run the following commands in your DOS environment:
 ```batch
 cd <directory where NIVPlus is installed>
 cd modules

--- a/dosbox.conf
+++ b/dosbox.conf
@@ -1,0 +1,4 @@
+[cpu]
+core               = dynamic_x86
+cputype            = pentium_iii
+cycles             = max


### PR DESCRIPTION
Running this game performantly on modern Windows computers is non-intuitive. Even when following the README, users often struggle to get the game running at all, and when they do, it is 2-3 FPS.

This adds 2 things to Noctis IV Plus:
- A `dosbox.conf` file which can be used with DOSBox-X to optimize performance when running Noctis IV
- An intelligent launcher script (Windows Batch) which launches DOSBox-X and automatically runs the required commands to get Noctis IV started

By default, the script looks for the installed DOSBox-X binary at `C:\DOSBox-X\dosbox-x.exe`. If this does not exist, the script will instead look for a portable installation of DOSBox-X in `%SCRIPT_DIR%\bin\x64\Release\dosbox-x.exe`. This allows the script to be used in either an installed configuration (on a hard drive) or a portable configuration (on a removable drive).

This script effectively turns Noctis IV / Noctis IV Plus into a double-click-to-run program on modern Windows operating systems.