### PR TITLE
Revamped compile script and created a detailed guide for compiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ source/BIN/*
 
 *.zip
 /bc.31
+/bin

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ movies/*
 source/BIN/*
 
 *.zip
+/bc.31

--- a/README.md
+++ b/README.md
@@ -33,10 +33,5 @@ noctis.exe
 To compile Noctis IV Plus, follow these steps:
 
 1. Get a working MS-DOS setup, as per the above.
-2. Install Borland C++ 3.1 for DOS to `c:\bc.31`
-3. Run the following from within the MS-DOS environment:
-```batch
-cd <directory where NIVPlus is installed>
-cd source
-compile.bat
-```
+2. Install [Borland C++ 3.1 for DOS](https://archive.org/download/bcpp31/BCPP31.ZIP) to `Noctis-IV-Plus\bc.31`
+3. Double-click `source\Build.bat` to run the build script.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ noctis.exe
 
 ## Compiling
 
+*For a more detailed guide, [click here](source/README.md).*
+
 To compile Noctis IV Plus, follow these steps:
 
 1. Get a working MS-DOS setup, as per the above.

--- a/dosbox.conf
+++ b/dosbox.conf
@@ -1,0 +1,4 @@
+[cpu]
+core               = dynamic_x86
+cputype            = pentium_iii
+cycles             = max

--- a/source/Build.bat
+++ b/source/Build.bat
@@ -73,4 +73,6 @@ if not exist "%BCPP31_DIR%\BIN\MAKE.EXE" (
     exit /b
 )
 
+
+
 "%DOSBOX_X_BIN%" -c "mount n '%MOUNT_DIR%'" -c "n:" -c "cd source" -c "compile.bat" -exit

--- a/source/Build.bat
+++ b/source/Build.bat
@@ -1,0 +1,76 @@
+@echo off
+
+set SCRIPT_DIR=%~dp0
+set SCRIPT_DIR=%SCRIPT_DIR:~0,-1%
+
+set NIVP_DIR=%SCRIPT_DIR%\..
+pushd %NIVP_DIR%
+set NIVP_DIR=%CD%
+popd
+
+set DBX_BIN_INSTALLED=C:\DOSBox-X\dosbox-x.exe
+set DBX_BIN_PORTABLE=%NIVP_DIR%\bin\x64\Release\dosbox-x.exe
+
+set MOUNT_DIR=%NIVP_DIR%
+
+set BCPP31_DIR=%MOUNT_DIR%\bc.31
+
+echo.
+echo ^+------------------------^+
+echo ^| Noctis IV Plus Builder ^|
+echo ^+------------------------^+
+echo.
+
+if exist "%DBX_BIN_INSTALLED%" (
+    echo DOSBox-X installation found!
+    set PORTABLE=0
+    set DOSBOX_X_BIN=%DBX_BIN_INSTALLED%
+) else (
+    echo DOSBox-X is not installed! Looking for portable version...
+    if exist "%DBX_BIN_PORTABLE%" (
+        echo Portable DOSBox-X found!
+        set PORTABLE=1
+        set DOSBOX_X_BIN=%DBX_BIN_PORTABLE%
+    ) else (
+        echo Could not find portable DOSBox-X!
+        echo.
+        echo ERROR: No DOSBox-X binary found! Unable to launch!
+        echo Download DOSBox-X from here: https://github.com/joncampbell123/dosbox-x/releases/latest
+        echo.
+        <nul set /p "=Press any key to exit . . . "
+        pause >nul
+        exit /b
+    )
+)
+
+echo.
+
+if "%PORTABLE%"=="1" (
+    echo Using portable binary: "%DOSBOX_X_BIN%"
+) else (
+    echo Using installed binary: "%DOSBOX_X_BIN%"
+)
+
+if not exist "%MOUNT_DIR%\source\compile.bat" (
+    echo.
+    echo ERROR: Noctis IV / IV Plus not found! Unable to launch!
+    echo Download Noctis IV here: https://80.style/packs/zip/hsp/noctis_iv-noctis_iv_download_JmsLdos_onlyK
+    echo Download Noctis IV Plus from here: https://github.com/jorisvddonk/Noctis-IV-Plus/releases/latest
+    echo.
+    <nul set /p "=Press any key to exit . . . "
+    pause >nul
+    exit /b
+)
+
+if not exist "%BCPP31_DIR%\BIN\MAKE.EXE" (
+    echo.
+    echo ERROR: Borland C++ 3.1 not found! Unable to launch!
+    echo Download Borland C++ 3.1 here: https://archive.org/download/bcpp31/BCPP31.ZIP
+    echo Extract the contents to: %BCPP31_DIR%
+    echo.
+    <nul set /p "=Press any key to exit . . . "
+    pause >nul
+    exit /b
+)
+
+"%DOSBOX_X_BIN%" -c "mount n '%MOUNT_DIR%'" -c "n:" -c "cd source" -c "compile.bat" -exit

--- a/source/Build.bat
+++ b/source/Build.bat
@@ -11,6 +11,7 @@ popd
 set DBX_BIN_INSTALLED=C:\DOSBox-X\dosbox-x.exe
 set DBX_BIN_PORTABLE=%NIVP_DIR%\bin\x64\Release\dosbox-x.exe
 
+set CONF_FILE=%NIVP_DIR%\dosbox.conf
 set MOUNT_DIR=%NIVP_DIR%
 
 set BCPP31_DIR=%MOUNT_DIR%\bc.31
@@ -51,6 +52,19 @@ if "%PORTABLE%"=="1" (
     echo Using installed binary: "%DOSBOX_X_BIN%"
 )
 
+if exist "%CONF_FILE%" (
+    echo Using conf file: "%CONF_FILE%"
+) else (
+    echo Could not find conf file: "%CONF_FILE%"
+    echo.
+    echo ERROR: Configuration file not found! Unable to launch!
+    echo Download here: https://github.com/jorisvddonk/Noctis-IV-Plus/raw/refs/heads/master/dosbox.conf
+    echo.
+    <nul set /p "=Press any key to exit . . . "
+    pause >nul
+    exit /b
+)
+
 if not exist "%MOUNT_DIR%\source\compile.bat" (
     echo.
     echo ERROR: Noctis IV / IV Plus not found! Unable to launch!
@@ -75,4 +89,4 @@ if not exist "%BCPP31_DIR%\BIN\MAKE.EXE" (
 
 
 
-"%DOSBOX_X_BIN%" -c "mount n '%MOUNT_DIR%'" -c "n:" -c "cd source" -c "compile.bat" -exit
+"%DOSBOX_X_BIN%" -c "mount n '%MOUNT_DIR%'" -c "n:" -c "cd source" -c "compile.bat" -conf "%CONF_FILE%" -exit

--- a/source/NOCTIS.CFG
+++ b/source/NOCTIS.CFG
@@ -13,5 +13,5 @@
 -weas
 -wpre
 -n.\BIN
--IC:\BC.31\INCLUDE
--LC:\BC.31\LIB
+-IN:\BC.31\INCLUDE
+-LN:\BC.31\LIB

--- a/source/NOCTIS.MAK
+++ b/source/NOCTIS.MAK
@@ -7,8 +7,8 @@ CC = bcc +NOCTIS.CFG
 TASM = tasm
 TLIB = tlib
 TLINK = tlink
-LIBPATH = C:\BC.31\LIB
-INCLUDEPATH = C:\BC.31\INCLUDE
+LIBPATH = N:\BC.31\LIB
+INCLUDEPATH = N:\BC.31\INCLUDE
 
 
 #		*Implicit Rules*

--- a/source/README.md
+++ b/source/README.md
@@ -1,0 +1,37 @@
+# How To Compile Noctis IV Plus
+No DeLorean needed for this trip through time. You will however need a computer capable of running DOSBox-X.
+
+## Preparing The DOSBox-X Build Environment
+Before moving onto the following steps, [download DOSBox-X from here](https://dosbox-x.com/) and install it to it's default location. All the default settings should be good.
+
+### Setup A DOSBox-X `C:` Drive Folder
+1. Make a new folder in your root directory named `DOS_C`.
+    - On `Windows`, the root directory is `C:`, so your DOS `C:` drive directory should be `C:\DOS_C\`.
+    - On `*nix`, the root directory is `/`, so your DOS `C:` drive directory should be `/DOS_C/`.
+2. Open DOSBox-X. From the toolbar, select `Main > Configuration tool`.
+3. Click the `AUTOEXEC.BAT` button on the popup window.
+4. Enter the following into the text box window, replacing `{DOS_C}` with your DOS `C:` drive directory:
+```
+mount C {DOS_C}
+c:
+```
+5. Click `OK`.
+6. Click `Save...`, and then click `Save` again on the popup.
+7. Click `Close` and then close DOSBox-X.
+
+### Install Borland C++ 3.1 for DOS
+1. Download Borland C++ 3.1 for DOS here: [BCPP31.ZIP](https://archive.org/download/bcpp31/BCPP31.ZIP).
+2. Make a new folder on your DOS `C:` drive named `bc.31`.
+3. Extract the contents of the `BCPP31.ZIP` file to the `bc.31` folder to finish the install.
+
+### Copy The Noctis Folder
+Make a copy of the `Noctis-IV-Plus` folder in the root of your DOS `C:` drive.
+
+## Compiling
+1. Open DOSBox-X.
+2. Run the command `cd Noctis-IV-Plus\source` in order to switch to the source code directory.
+3. Run the command `compile.bat`.
+    - If the build failed, it will let you know and prompt you to press a key to exit.
+    - If the build succeeded, it will prompt you to press a key to run the newly compiled Noctis IV Plus.
+
+The compiled binary is automatically copied over to the `modules` folder inside the main `Noctis-IV-Plus` folder.

--- a/source/README.md
+++ b/source/README.md
@@ -2,36 +2,20 @@
 No DeLorean needed for this trip through time. You will however need a computer capable of running DOSBox-X.
 
 ## Preparing The DOSBox-X Build Environment
-Before moving onto the following steps, [download DOSBox-X from here](https://dosbox-x.com/) and install it to it's default location. All the default settings should be good.
+Before moving onto the following steps, [download DOSBox-X from here](https://dosbox-x.com/) and install it to it's default location `C:\DOSBox-X\dosbox-x.exe`. All the default settings should be good.
 
-### Setup A DOSBox-X `C:` Drive Folder
-1. Make a new folder in your root directory named `DOS_C`.
-    - On `Windows`, the root directory is `C:`, so your DOS `C:` drive directory should be `C:\DOS_C\`.
-    - On `*nix`, the root directory is `/`, so your DOS `C:` drive directory should be `/DOS_C/`.
-2. Open DOSBox-X. From the toolbar, select `Main > Configuration tool`.
-3. Click the `AUTOEXEC.BAT` button on the popup window.
-4. Enter the following into the text box window, replacing `{DOS_C}` with your DOS `C:` drive directory:
-```
-mount C {DOS_C}
-c:
-```
-5. Click `OK`.
-6. Click `Save...`, and then click `Save` again on the popup.
-7. Click `Close` and then close DOSBox-X.
+Alternatively, you can download the portable version and extract it's `bin` folder to the main `Noctis-IV-Plus` folder.
 
 ### Install Borland C++ 3.1 for DOS
 1. Download Borland C++ 3.1 for DOS here: [BCPP31.ZIP](https://archive.org/download/bcpp31/BCPP31.ZIP).
-2. Make a new folder on your DOS `C:` drive named `bc.31`.
+2. Make a new folder in the main `Noctis-IV-Plus` folder named `bc.31`.
 3. Extract the contents of the `BCPP31.ZIP` file to the `bc.31` folder to finish the install.
 
-### Copy The Noctis Folder
-Make a copy of the `Noctis-IV-Plus` folder in the root of your DOS `C:` drive.
-
 ## Compiling
-1. Open DOSBox-X.
-2. Run the command `cd Noctis-IV-Plus\source` in order to switch to the source code directory.
-3. Run the command `compile.bat`.
-    - If the build failed, it will let you know and prompt you to press a key to exit.
-    - If the build succeeded, it will prompt you to press a key to run the newly compiled Noctis IV Plus.
+1. Double-click `source\Build.bat` to run the build script.
+    - It will prompt you if anything is missing.
+    - If everything is downloaded correctly, it will open DOSBox-X for compilation.
+        - If the build fails, it will let you know and prompt you to press a key to exit.
+        - If the build succeeds, it will prompt you to press a key to run the newly compiled Noctis IV Plus.
 
 The compiled binary is automatically copied over to the `modules` folder inside the main `Noctis-IV-Plus` folder.

--- a/source/compile.bat
+++ b/source/compile.bat
@@ -1,26 +1,49 @@
-rem @echo off
-set path=C:\bc.31\bin;C:\bc.31\INCLUDE
-rem set INCLUDE=C:\bc.31\INCLUDE
-if not exist bin mkdir bin
-cd bin
-rem del *.* /q
-cd ..
+@echo off
 
-if exist bin\noctis.exe del bin\noctis.exe
+rem Change this to point to the installation directory for Borland C++ 3.1
+rem This should be relative to the DOS C: drive, not your main C: drive
+set BCPP31_DIR=C:\bc.31
+
+
+
+echo Building Noctis IV Plus...
+
+rem Append Borland C++ 3.1 to the PATH
+set PATH=%PATH%;%BCPP31_DIR%\bin;%BCPP31_DIR%\INCLUDE
+
+rem Ensure the 'bin' folder exists and is empty
+if exist bin\NUL deltree /Y bin
+mkdir bin
+
+rem Build Noctis IV using the make tool
 make -fnoctis.mak -DALL=DEF_ALL -B
+
+rem Handle failure to build
 if exist bin\noctis.exe goto success
+echo Build failed!
 pause
 goto done
 
+rem Handle successful build
 :success
+echo Build completed successfully!
+
+rem Move built executable
+echo Moving built executable to modules folder...
 copy bin\noctis.exe ..\modules\noctis.exe /y
 copy supports.nct ..\data /y
+del bin\noctis.exe
+echo Executable moved successfully!
 
-rem del noctis.exe
-pause
-:done
+rem Pause before running
+echo Press any key to run Noctis IV Plus . . .
+pause >nul
 
+rem Run Noctis IV
 cd ..
 modules\noctis.exe
 cd ..
 cd source
+
+rem End of program
+:done

--- a/source/compile.bat
+++ b/source/compile.bat
@@ -21,7 +21,8 @@ make -fnoctis.mak -DALL=DEF_ALL -B
 rem Handle failure to build
 if exist bin\noctis.exe goto success
 echo Build failed!
-pause
+echo Press any key to exit . . .
+pause >nul
 goto done
 
 rem Handle successful build

--- a/source/compile.bat
+++ b/source/compile.bat
@@ -1,8 +1,8 @@
 @echo off
 
 rem Change this to point to the installation directory for Borland C++ 3.1
-rem This should be relative to the DOS C: drive, not your main C: drive
-set BCPP31_DIR=C:\bc.31
+rem The N: drive is the Noctis-IV-Plus folder
+set BCPP31_DIR=N:\bc.31
 
 
 


### PR DESCRIPTION
To make compiling easier for people new to the project and to remove confusion about what has changed since the original build instructions, I have made a Markdown file that will display as the main `README.md` for the `source` directory of the repo.

I have also cleaned up the compile script in many ways, such as
- Handling the `PATH` append correctly
- Handling the `bin` folder cleaning correctly
- Making it easier to change the Borland C++ install directory
- Printing more helpful messages
- Only running the game when a build is successful
- Removing the dependency on a `C:` drive, the `N:` drive is the `Noctis-IV-Plus` directory
- Borland C++ 3.1 is expected to be installed locally at `Noctis-IV-Plus\bc.31`

In addition, I have added a `Build.bat` script for use on Windows systems. It can use either a normal install of DOSBox-X at `C:\DOSBox-X\dosbox-x.exe` or a portable installation in the `Noctis-IV-Plus\bin` directory.

I have tested these instructions and the new compile script on a Windows 11 PC, and it has worked flawlessly.