### PR TITLE
Added HUD toggle

### DIFF
--- a/source/NOCTIS-0.CPP
+++ b/source/NOCTIS-0.CPP
@@ -6109,26 +6109,33 @@ float	tp_temp = 22, pp_temp = 22;
 float	tp_pressure = 1, pp_pressure = 1;
 float	tp_pulse = 118, pp_pulse = 118;
 
+// Variables for HUD toggle (nimaid)
+extern char draw_hud;
+extern char about;
+char taking_snapshot = 0;
+
 void wrouthud (unsigned x, unsigned y, unsigned l, char *text)
 {
-	int j, i, n;
-	unsigned spot;
+    if (draw_hud == 1 || about == 1 || taking_snapshot == 1) {
+        int j, i, n;
+        unsigned spot;
 
-	n = 0; if (!l) l = 32767;
-	spot = y * 320 + x;
+        n = 0; if (!l) l = 32767;
+        spot = y * 320 + x;
 
-	while (text[n] && n < l) {
-		j = (text[n] - 32) * 5;
-		for (i = 0; i < 5; i++) {
-			if (digimap[j + i] & 1) adapted[spot+0] = 191 - adapted[spot+0];
-			if (digimap[j + i] & 2) adapted[spot+1] = 191 - adapted[spot+1];
-			if (digimap[j + i] & 4) adapted[spot+2] = 191 - adapted[spot+2];
-			spot += 320;
-		}
-		spot -= 320 * 5;
-		spot += 4;
-		n++;
-	}
+        while (text[n] && n < l) {
+            j = (text[n] - 32) * 5;
+            for (i = 0; i < 5; i++) {
+                if (digimap[j + i] & 1) adapted[spot+0] = 191 - adapted[spot+0];
+                if (digimap[j + i] & 2) adapted[spot+1] = 191 - adapted[spot+1];
+                if (digimap[j + i] & 4) adapted[spot+2] = 191 - adapted[spot+2];
+                spot += 320;
+            }
+            spot -= 320 * 5;
+            spot += 4;
+            n++;
+        }
+    }
 }
 
 char blinkhudlights;
@@ -6145,7 +6152,9 @@ void surrounding (char compass_on, int openhudcount)
 	long	lsecs, lptr;
 	float	pp_delta, ccom;
 
-	for (lptr=0; lptr<04; lptr++) areaclear (adapted, 10, openhudcount + 9 - lptr, 0, 0, 300, 1, 54 + surlight + 3*lptr);
+	if (draw_hud == 1) {
+        for (lptr=0; lptr<04; lptr++) areaclear (adapted, 10, openhudcount + 9 - lptr, 0, 0, 300, 1, 54 + surlight + 3*lptr);
+    }
 	for (lptr=0; lptr<10; lptr++) areaclear (adapted, 0, 9 - lptr, 0, 0, 320, 1, 64 + surlight - lptr);
 	for (lptr=0; lptr<10; lptr++) areaclear (adapted, 0, 190 + lptr, 0, 0, 320, 1, 64 + surlight - lptr);
 	for (lptr=0; lptr<10; lptr++) areaclear (adapted, 9 - lptr, 10, 0, 0, 1, 180, 64 + surlight - lptr);
@@ -6156,6 +6165,7 @@ void surrounding (char compass_on, int openhudcount)
 
 //Turn on (and make a bit larger) those lights. Blinkhudlights turns them on, and Blinkhudlights_stay
 //makes them either turn off again, or stay on until Blinkhudlights is set to 0 again.
+    if (draw_hud == 0) goto no_hud_lights;
 	if (blinkhudlights == 1) {
 		if (lptr <= 111)
 		lptr = 127;
@@ -6192,6 +6202,7 @@ void surrounding (char compass_on, int openhudcount)
 		areaclear (adapted, 308, 188, 0, 0, 4, 4, lptr);
 		smootharound_64 (adapted, 308, 188, 5, 1);
 	}
+    no_hud_lights:
 
 	sprintf (outhudbuffer, "EPOC %d & ", epoc);
 	lsecs = secs; lsecs -= lsecs % 1000000L; lsecs /= 1000000L; lsecs%=1000;
@@ -6272,12 +6283,14 @@ int movieexists;
 char snapfilename[24];
 void snapshot (int forcenumber, char showdata)
 {
-    	long prog;
+    long prog;
 	unsigned pqw;
 	double parsis_x, parsis_y, parsis_z;
 
 	unsigned ptr, c;
 	char a, b, t[54];
+    
+    taking_snapshot = 1;
 
 	int ih = sa_open (header_bmp);
 	if (ih==-1) return;
@@ -6334,47 +6347,59 @@ void snapshot (int forcenumber, char showdata)
 		sprintf (snapfilename, "..\\GALLERY\\WIDE%04d.BMP", forcenumber);	//Panoramic snapshots no longer overwrite pictures 9997-9999 if those happened to exist. (SL)
 
     if (showdata) {
-	areaclear (adapted, 2, 191, 0, 0, 316, 7, 64 + 63);
+        areaclear (adapted, 2, 191, 0, 0, 316, 7, 64 + 63);
 
-	asm {	fld dzat_x
-		frndint
-		fstp parsis_x
-		fld dzat_y
-		frndint
-		fstp parsis_y
-		fld dzat_z
-		frndint
-		fstp parsis_z }
+        asm {	fld dzat_x
+            frndint
+            fstp parsis_x
+            fld dzat_y
+            frndint
+            fstp parsis_y
+            fld dzat_z
+            frndint
+            fstp parsis_z }
 
-	strcpy (outhudbuffer, "LOCATION PARSIS: ");
-	strcat (outhudbuffer, alphavalue(parsis_x));
-	strcat (outhudbuffer, ";");
-	strcat (outhudbuffer, alphavalue(-parsis_y));
-	strcat (outhudbuffer, ";");
-	strcat (outhudbuffer, alphavalue(parsis_z));
-	if (ip_targetted > -1) {
-		if (nearstar_p_owner[ip_targetted] > -1) {
-			strcat (outhudbuffer, " & TGT: MOON N@");
-			strcat (outhudbuffer, alphavalue(nearstar_p_moonid[ip_targetted]+1));
-			strcat (outhudbuffer, " OF PLANET N@");
-			strcat (outhudbuffer, alphavalue(nearstar_p_owner[ip_targetted]+1));
-		}
-		else {
-			strcat (outhudbuffer, " & TGT: PLANET N@");
-			strcat (outhudbuffer, alphavalue(ip_targetted+1));
-		}
-	}
-	wrouthud (3, 192, NULL, outhudbuffer);
+        strcpy (outhudbuffer, "LOCATION PARSIS: ");
+        strcat (outhudbuffer, alphavalue(parsis_x));
+        strcat (outhudbuffer, ";");
+        strcat (outhudbuffer, alphavalue(-parsis_y));
+        strcat (outhudbuffer, ";");
+        strcat (outhudbuffer, alphavalue(parsis_z));
+        if (ip_targetted > -1) {
+            if (nearstar_p_owner[ip_targetted] > -1) {
+                strcat (outhudbuffer, " & TGT: MOON N@");
+                strcat (outhudbuffer, alphavalue(nearstar_p_moonid[ip_targetted]+1));
+                strcat (outhudbuffer, " OF PLANET N@");
+                strcat (outhudbuffer, alphavalue(nearstar_p_owner[ip_targetted]+1));
+            }
+            else {
+                strcat (outhudbuffer, " & TGT: PLANET N@");
+                strcat (outhudbuffer, alphavalue(ip_targetted+1));
+            }
+        }
+        wrouthud (3, 192, NULL, outhudbuffer);
 
-	if (ap_targetted == 1 && star_label_pos != -1) {
-		areaclear (adapted, 14, 14, 0, 0, 102, 7, 64 + 63);
-		wrouthud (15, 15, 20, star_label);
-	}
+        if (ap_targetted == 1 && star_label_pos != -1) {
+            if (draw_hud == 1) {
+                areaclear (adapted, 14, 14, 0, 0, 102, 7, 64 + 63);
+                wrouthud (15, 15, 20, star_label);
+            }
+            else {
+                areaclear (adapted, 2, 2, 0, 0, 102, 7, 64 + 63);
+                wrouthud (3, 3, 20, star_label);
+            }
+        }
 
-	if (ip_targetted != -1 && planet_label_pos != -1) {
-		areaclear (adapted, 14, 23, 0, 0, 102, 7, 64 + 63);
-		wrouthud (15, 24, 20, planet_label);
-	}
+        if (ip_targetted != -1 && planet_label_pos != -1) {
+            if (draw_hud == 1) {
+                areaclear (adapted, 14, 23, 0, 0, 102, 7, 64 + 63);
+                wrouthud (15, 24, 20, planet_label);
+            }
+            else {
+                areaclear (adapted, 2, 11, 0, 0, 102, 7, 64 + 63);
+                wrouthud (3, 12, 20, planet_label);
+            }
+        }
     }
 
 	ih = _creat (snapfilename, 0);
@@ -6390,6 +6415,8 @@ void snapshot (int forcenumber, char showdata)
 		for (ptr=63680; ptr<64000; ptr-=320) _write (ih, adapted+ptr, 320);
 		_close (ih);
 	}
+    
+    taking_snapshot = 0;
 }
 
 /*

--- a/source/NOCTIS-1.CPP
+++ b/source/NOCTIS-1.CPP
@@ -3717,6 +3717,7 @@ void planetary_main ()
 	long	prog;
 	long	line;
 	extern char about;
+    extern char draw_hud;
 
 	exitflag = 0;
 
@@ -4511,7 +4512,7 @@ void planetary_main ()
 		// subito dopo che si � stati bagnati da un'onda...
 	  ends: 
 	  	// trying to have status on surface working (neuzd)
-	  	if (fcs_status_delay>0) {
+	  	if (fcs_status_delay>0 && draw_hud == 1) {
 			int len = strlen(fcs_status_extended);
 			len = len+len;
 			wrouthud(160-len, 100, NULL, fcs_status_extended);
@@ -4543,7 +4544,14 @@ void planetary_main ()
 		}
 		
 		// il fotogramma � finito. ora lo visualizza.
-		surrounding (1, openhudcount);
+        if (draw_hud != -1) {
+            if (draw_hud == 1) {
+                surrounding (1, openhudcount);
+            }
+            else {
+                surrounding (0, openhudcount);
+            }
+        }
 		QUADWORDS = 16000;
 		if (!widesnapping) pcopy (adaptor, adapted);
 		QUADWORDS = pqw;
@@ -4734,23 +4742,40 @@ void planetary_main ()
 				}
 				
 				if (w==0x3D){								// f3 - moviestat
-					if (moviestat == 0){
-						moviestat = 1;
-						about = 0;
-					}
-					else {
-						moviestat = 0;
-					}
+					if (draw_hud == 1) {
+                        if (moviestat == 0){
+                            moviestat = 1;
+                            about = 0;
+                        }
+                        else {
+                            moviestat = 0;
+                        }
+                    }
 				}
 				if (w==0x3B) { // F1 - help & about
 					if (about == 0){
 						about = 1;
 						moviestat = 0;
+                        draw_hud = 1;
 					}
 					else {
 						about = 0;
 					}
 				}
+                if (w==0x3C) { // F2 - HUD toggle
+                    if (about == 0) {
+                        if (draw_hud == 1) {
+                            draw_hud = 0;
+                            moviestat = 0;
+                        }
+                        else if (draw_hud == 0) {
+                            draw_hud = -1;
+                        }
+                        else {
+                            draw_hud = 1;
+                        }
+                    }
+                }
 				if (w == 0x48){
 					//user_alfa = user_alfa - 1;
 					option_mouseLook++;

--- a/source/NOCTIS-1.CPP
+++ b/source/NOCTIS-1.CPP
@@ -4544,13 +4544,11 @@ void planetary_main ()
 		}
 		
 		// il fotogramma � finito. ora lo visualizza.
-        if (draw_hud != -1) {
-            if (draw_hud == 1) {
-                surrounding (1, openhudcount);
-            }
-            else {
-                surrounding (0, openhudcount);
-            }
+        if (draw_hud == 1) {
+            surrounding (1, openhudcount);
+        }
+        else {
+            surrounding (0, openhudcount);
         }
 		QUADWORDS = 16000;
 		if (!widesnapping) pcopy (adaptor, adapted);

--- a/source/NOCTIS-1.CPP
+++ b/source/NOCTIS-1.CPP
@@ -4766,9 +4766,6 @@ void planetary_main ()
                             draw_hud = 0;
                             moviestat = 0;
                         }
-                        else if (draw_hud == 0) {
-                            draw_hud = -1;
-                        }
                         else {
                             draw_hud = 1;
                         }

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -3916,9 +3916,6 @@ void main ()
                             draw_hud = 0;
                             moviestat = 0;
                         }
-                        else if (draw_hud == 0) {
-                            draw_hud = -1;
-                        }
                         else {
                             draw_hud = 1;
                         }

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -1188,6 +1188,9 @@ int moviepaused=0;
 
 char about = 0;
 
+// Variables for HUD toggle (nimaid)
+char draw_hud = 1;
+
 unsigned char far * ctrlkeys     = (unsigned char far *) 0x00000417;
 
 char   aso_countdown = 100;	// contatore per la funzione "autoscreenoff"
@@ -2787,7 +2790,7 @@ void main ()
 		// Fornisce informazioni sullo strato esterno dell'H.U.D.
 		// Qualsiasi glifo verr� in seguito trattato con dithering.
 		//
-		if (active_screen != -1) goto nohud_1;
+		if (active_screen != -1 || draw_hud != 1) goto nohud_1;
 		//
 		// Informazioni e schemi addizionali sull'H.U.D.
 		// Tracciamento label della stella selezionata.
@@ -2867,12 +2870,14 @@ void main ()
 		//
        nohud_1: alfa = 0; beta = 0; change_angle_of_view ();
 		cam_x = -512; cam_y = -275; cam_z = -750;
-		c = strlen(fcs_status_extended) - 1;
-		while (c >= 0) {
-			digit_at (fcs_status_extended[c], -6, -15, 6, 120, 1);
-			cam_x += 45;
-			c--;
-		}
+        if (draw_hud == 1) {
+            c = strlen(fcs_status_extended) - 1;
+            while (c >= 0) {
+                digit_at (fcs_status_extended[c], -6, -15, 6, 120, 1);
+                cam_x += 45;
+                c--;
+            }
+        }
 		//
 		// Link alla funzione di ricerca dei targets in real-time.
 		//
@@ -3528,7 +3533,9 @@ void main ()
 		// disegna i bordi dello scafandro, illuminati in relazione
 		// all'ambiente circostante.
 		//
-		surrounding (0, 180);
+        if (draw_hud != -1) {
+            surrounding (0, 180);
+        }
 		// riduzione stanchezza (continua, eventualmente
 		// dall'ultima volta che si � scesi in superficie)
 		// e variazioni nelle pulsazioni, pi� verosimili...
@@ -3897,44 +3904,61 @@ void main ()
 					if (about == 0){
 						about = 1;
 						moviestat = 0;
+                        draw_hud = 1;
 					}
 					else {
 						about = 0;
 					}
 				}
-				if (c==0x3D){								// f3 - moviestat
-					if (moviestat == 0){
-						moviestat = 1;
-						
-						char tempsnapfile[24];
-						if (movieexists == 0)
-						{								//let's check if the moviedeck exists already.... But only if the moviedeck has been changed lately.
-							//wrouthud (10,90, NULL, "CHECKING!!!");
-							sprintf (tempsnapfile, "..\\MOVIES\\%03i\\00000001.BMP", moviedeck);
-							FILE * tmpFile = fopen(tempsnapfile, "r");
-							if (tmpFile == NULL) {
-								movieexists = 1;
-							} else {
-								movieexists = 2;
-							}
-							fclose(tmpFile);
-						}
-						char  short_text[11];
-						if (movieexists == 2)
-						{
-							sprintf (short_text, "%i EXISTS", moviedeck);
-							status(short_text,100);
-						}
-						else
-						{
-							sprintf (short_text, "MD %i FREE", moviedeck);
-							status(short_text,100);
-						}
-					}
-					else {
-						moviestat = 0;
-						status("MVMENU OFF",100);
-					}
+                if (c==0x3C) { // F2 - HUD toggle
+                    if (about == 0) {
+                        if (draw_hud == 1) {
+                            draw_hud = 0;
+                            moviestat = 0;
+                        }
+                        else if (draw_hud == 0) {
+                            draw_hud = -1;
+                        }
+                        else {
+                            draw_hud = 1;
+                        }
+                    }
+                }
+				if (c==0x3D){ // f3 - moviestat
+					if (draw_hud == 1) {
+                        if (moviestat == 0){
+                            moviestat = 1;
+                            
+                            char tempsnapfile[24];
+                            if (movieexists == 0)
+                            {								//let's check if the moviedeck exists already.... But only if the moviedeck has been changed lately.
+                                //wrouthud (10,90, NULL, "CHECKING!!!");
+                                sprintf (tempsnapfile, "..\\MOVIES\\%03i\\00000001.BMP", moviedeck);
+                                FILE * tmpFile = fopen(tempsnapfile, "r");
+                                if (tmpFile == NULL) {
+                                    movieexists = 1;
+                                } else {
+                                    movieexists = 2;
+                                }
+                                fclose(tmpFile);
+                            }
+                            char  short_text[11];
+                            if (movieexists == 2)
+                            {
+                                sprintf (short_text, "%i EXISTS", moviedeck);
+                                status(short_text,100);
+                            }
+                            else
+                            {
+                                sprintf (short_text, "MD %i FREE", moviedeck);
+                                status(short_text,100);
+                            }
+                        }
+                        else {
+                            moviestat = 0;
+                            status("MVMENU OFF",100);
+                        }
+                    }
 				}
 				if (c==144 && moviestat && !movie) {					//add 1 to moviedeck
 					if (moviedeck < 999) {
@@ -4384,12 +4408,11 @@ void ShowAboutPage(char surface) {
 		wrouthud (14,65, NULL,   "SPACE - JETPACK                             C - DISENGAGE JETPACK CONTROL");
 		wrouthud (14,71, NULL,   "M OR ASTERISK - SNAPSHOT                    N OR / - WIDE SNAPSHOT");
 		wrouthud (14,77, NULL,   "B OR DELETE - RAW SNAPSHOT");
-		wrouthud (14,83, NULL,   "F3 - MOVIEMAKER");
-		wrouthud (14,89, NULL,  "UP ARROW - TOGGLE MOUSELOOK");
+		wrouthud (14,83, NULL,   "F3 - MOVIEMAKER                             F2 - TOGGLE HUD");
 	} else {
 		wrouthud (14, 37, NULL, "SHORTCUT KEYS (WHEN IN SPACE):");
 		wrouthud (14, 53, NULL, "M OR ASTERISK - SNAPSHOT                     B - RAW SNAPSHOT");
-		wrouthud (14, 59, NULL, "F3 - MOVIEMAKER");
+		wrouthud (14, 59, NULL, "F3 - MOVIEMAKER                              F2 - TOGGLE HUD");
 		wrouthud (14, 65, NULL, "TAB - TOGGLE ANTIALIASING");
 		wrouthud (14, 71, NULL, "S - TOGGLE ROOFSPEED");
 	}


### PR DESCRIPTION
The HUD can sometimes be distracting and can often interfere with both regular and wide snapshots. Additionally, it is glitchy when showing up in wide snapshots.

This adds 2 HUD states that can be toggled with `F2`:
- On (normal)
- Off w/ border (covers framebuffer artifacts)