### PR TITLE
Added raw wide snapshot

### DIFF
--- a/source/NOCTIS-1.CPP
+++ b/source/NOCTIS-1.CPP
@@ -3342,6 +3342,7 @@ void planetary_main ()
 	int	 openhuddelta = 0;
 	char	 hud_closed   = 1;
 	char	 widesnapping = 0;
+    char     raw_widesnap = 0;
 
 	int 	 w, lw = 10, now = 25, waveratio = 5, waveblur = 0;
 	int      flick, flicks, fshift;
@@ -4602,7 +4603,12 @@ void planetary_main ()
 				dzat_x = backup_dzat_x;
 				dzat_y = backup_dzat_y;
 				dzat_z = backup_dzat_z;
-				snapshot (9997+widesnapping, 1);
+                if (raw_widesnap == 1) {
+                    snapshot (9997+widesnapping, 0);
+                }
+                else {
+                    snapshot (9997+widesnapping, 1);
+                }
 				dzat_x = 0;
 				dzat_y = 0;
 				dzat_z = 0;
@@ -4860,7 +4866,13 @@ void planetary_main ()
 				if ((w == '/' || w == 'n') && !widesnapping) {
 					snapshot (9997, 0);
 					widesnapping = 1;
+                    raw_widesnap = 0;
 				}
+                if ((w == 'v' || w == '+') && !widesnapping) {
+                    snapshot (9997, 0);
+					widesnapping = 1;
+                    raw_widesnap = 1;
+                }
 				if (w >= 48 && w <= 57) {
 					w = w - 48;
 					if (fixed_step == (w * 10))

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -4383,7 +4383,7 @@ void ShowAboutPage(char surface) {
 		wrouthud (14,59, NULL,   "J - JUMP                                    L - LAND ON SURFACE");
 		wrouthud (14,65, NULL,   "SPACE - JETPACK                             C - DISENGAGE JETPACK CONTROL");
 		wrouthud (14,71, NULL,   "M OR ASTERISK - SNAPSHOT                    N OR / - WIDE SNAPSHOT");
-		wrouthud (14,77, NULL,   "B OR DELETE - RAW SNAPSHOT");
+		wrouthud (14,77, NULL,   "B OR DELETE - RAW SNAPSHOT                  V OR + - RAW WIDE SNAPSHOT");
 		wrouthud (14,83, NULL,   "F3 - MOVIEMAKER");
 		wrouthud (14,89, NULL,  "UP ARROW - TOGGLE MOUSELOOK");
 	} else {


### PR DESCRIPTION
Players are able to take raw snapshots but not raw wide snapshots.

This adds the ability to take a raw wide snapshot with `V` or `+`.