### PR TITLE
Added ability to toggle antialiasing on the surface

### DIFF
--- a/source/NOCTIS-0.CPP
+++ b/source/NOCTIS-0.CPP
@@ -810,7 +810,7 @@ Word old_currentbin_length = 245;
 //Additional variables: (SL and Mega)
 Dword lastSnapshot = -1;				//0
 char option_mouseLook = 0;			//4
-char option_antialias_in_stardrifter = 1;
+char option_antialias = 1;
 
 Word new_currentbin_length = 5;
 char 	fcs_status_extended[42] = "STANDBY";

--- a/source/NOCTIS-0.H
+++ b/source/NOCTIS-0.H
@@ -161,7 +161,7 @@ extern char   surlight;
 extern Word old_currentbin_length;
 extern Dword   lastSnapshot;
 extern char   option_mouseLook;
-extern char   option_antialias_in_stardrifter;
+extern char   option_antialias;
 
 extern char   land_now;
 extern char   landing_point;

--- a/source/NOCTIS-1.CPP
+++ b/source/NOCTIS-1.CPP
@@ -4526,7 +4526,7 @@ void planetary_main ()
 			}
 			waveblur--;
 		}
-		else {
+		else if (option_antialias) {
 			QUADWORDS = 160 + openhudcount * 80;
 			psmooth_64 (adapted, 160);
 			psmooth_64 (adapted, 160);
@@ -4938,6 +4938,14 @@ void planetary_main ()
 						_close (sfh);
 						exitflag = 1;
 						goto nodissolve;
+					}
+				}
+                
+                if (w == 9) { // TAB - antialiasing on/off
+					if (option_antialias == 0) {
+						option_antialias = 1;
+					} else {
+						option_antialias = 0;
 					}
 				}
 			}

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -459,7 +459,7 @@ void freeze ()
 	WRITEFILE (fh, &lastSnapshot, sizeof(lastSnapshot));				//36
 	WRITEFILE (fh, &option_mouseLook, sizeof(option_mouseLook));				//40
 	WRITEFILE (fh, &roofspeed, sizeof(roofspeed));
-	WRITEFILE (fh, &option_antialias_in_stardrifter, sizeof(option_antialias_in_stardrifter));
+	WRITEFILE (fh, &option_antialias, sizeof(option_antialias));
 	_close (fh);
 }
 
@@ -1987,7 +1987,7 @@ void unfreeze ()
 		READFILE (fh, &lastSnapshot, sizeof(lastSnapshot));				//36
 		READFILE (fh, &option_mouseLook, sizeof(option_mouseLook));				//40
 		READFILE (fh, &roofspeed, sizeof(roofspeed));
-		READFILE (fh, &option_antialias_in_stardrifter, sizeof(option_antialias_in_stardrifter));
+		READFILE (fh, &option_antialias, sizeof(option_antialias));
 		strcpy(fcs_status_extended, fcs_status_extended);
 		_close (fh);
 	}
@@ -2930,7 +2930,7 @@ void main ()
 		// straordinariamente belli su uno schermo che, di per s�,
 		// � poco risolutivo, sia fisicamente che cromaticamente.
 		//
-		if (option_antialias_in_stardrifter){
+		if (option_antialias){
 			QUADWORDS -= 240;
 			psmooth_64 (adapted, 200);
 			psmooth_64 (adapted, 200);
@@ -4344,10 +4344,10 @@ void main ()
 				//if (c=='+' && surlight < 63) surlight++;
 				//if (c=='-' && surlight > 10) surlight--;
 				if (c==9) {								// TAB - antialiasing on/off
-					if (option_antialias_in_stardrifter == 0) {
-						option_antialias_in_stardrifter = 1;
+					if (option_antialias == 0) {
+						option_antialias = 1;
 					} else {
-						option_antialias_in_stardrifter = 0;
+						option_antialias = 0;
 					}
 				}
 			}
@@ -4386,6 +4386,7 @@ void ShowAboutPage(char surface) {
 		wrouthud (14,77, NULL,   "B OR DELETE - RAW SNAPSHOT");
 		wrouthud (14,83, NULL,   "F3 - MOVIEMAKER");
 		wrouthud (14,89, NULL,  "UP ARROW - TOGGLE MOUSELOOK");
+        wrouthud (14,95, NULL,   "TAB - TOGGLE ANTIALIASING");
 	} else {
 		wrouthud (14, 37, NULL, "SHORTCUT KEYS (WHEN IN SPACE):");
 		wrouthud (14, 53, NULL, "M OR ASTERISK - SNAPSHOT                     B - RAW SNAPSHOT");


### PR DESCRIPTION
Some people may enjoy the raw pixelated graphics on the surface, without antialiasing.

This PR changes the following:
- Makes the antialiasing option global
- Allows toggling antialiasing while on the surface with `TAB`