### PR TITLE
Fixed status messages going off screen in the stardrifter

### DIFF
--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -2869,7 +2869,7 @@ void main ()
 		cam_x = -512; cam_y = -275; cam_z = -750;
 		c = strlen(fcs_status_extended) - 1;
 		while (c >= 0) {
-			digit_at (fcs_status_extended[c], -6, -15, 6, 120, 1);
+			digit_at (fcs_status_extended[c], -6, -25, 6, 120, 1);
 			cam_x += 45;
 			c--;
 		}


### PR DESCRIPTION
The status messages in the stardrifter goes slightly off the bottom of the screen. This is most noticeable with antialiasing off.

This simply moves the status text up slightly so it looks good in both modes.