### PR TITLE
Added global visor effects, removed antialiasing toggle

### DIFF
--- a/source/NOCTIS-0.CPP
+++ b/source/NOCTIS-0.CPP
@@ -3651,7 +3651,9 @@ void lens_flares_for (double cam_x, double cam_y, double cam_z,
 	unsigned char temp;
 
 	int c, r;
-
+    
+    char on_hud_forced = (((on_hud == 1) && (lens_flare_mode == 0)) || (lens_flare_mode == 1));
+    
 	setfx (1);
 
 	xx = xlight - cam_x;
@@ -3683,7 +3685,7 @@ void lens_flares_for (double cam_x, double cam_y, double cam_z,
 				dx = lft_cos[c] * k * l;
 				dy = lft_sin[c] * k * l;
 				fline (xs-dx, ys-dy, xs+dx, ys+dy);
-				if (on_hud && !(c%8)) {
+				if (on_hud_forced && !(c%8)) {
 					dx /= 10; dy /= 10;
 					xr = (float)xs * -0.1;
 					yr = (float)ys * -0.1;

--- a/source/NOCTIS-0.CPP
+++ b/source/NOCTIS-0.CPP
@@ -6145,7 +6145,9 @@ void surrounding (char compass_on, int openhudcount)
 	long	lsecs, lptr;
 	float	pp_delta, ccom;
 
-	for (lptr=0; lptr<04; lptr++) areaclear (adapted, 10, openhudcount + 9 - lptr, 0, 0, 300, 1, 54 + surlight + 3*lptr);
+	if (option_antialias_in_stardrifter == 1) {
+        for (lptr=0; lptr<04; lptr++) areaclear (adapted, 10, openhudcount + 9 - lptr, 0, 0, 300, 1, 54 + surlight + 3*lptr);
+    }
 	for (lptr=0; lptr<10; lptr++) areaclear (adapted, 0, 9 - lptr, 0, 0, 320, 1, 64 + surlight - lptr);
 	for (lptr=0; lptr<10; lptr++) areaclear (adapted, 0, 190 + lptr, 0, 0, 320, 1, 64 + surlight - lptr);
 	for (lptr=0; lptr<10; lptr++) areaclear (adapted, 9 - lptr, 10, 0, 0, 1, 180, 64 + surlight - lptr);

--- a/source/NOCTIS-0.CPP
+++ b/source/NOCTIS-0.CPP
@@ -810,7 +810,6 @@ Word old_currentbin_length = 245;
 //Additional variables: (SL and Mega)
 Dword lastSnapshot = -1;				//0
 char option_mouseLook = 0;			//4
-char option_antialias_in_stardrifter = 1;
 
 Word new_currentbin_length = 5;
 char 	fcs_status_extended[42] = "STANDBY";
@@ -6145,9 +6144,8 @@ void surrounding (char compass_on, int openhudcount)
 	long	lsecs, lptr;
 	float	pp_delta, ccom;
 
-	if (option_antialias_in_stardrifter == 1) {
-        for (lptr=0; lptr<04; lptr++) areaclear (adapted, 10, openhudcount + 9 - lptr, 0, 0, 300, 1, 54 + surlight + 3*lptr);
-    }
+
+    for (lptr=0; lptr<04; lptr++) areaclear (adapted, 10, openhudcount + 9 - lptr, 0, 0, 300, 1, 54 + surlight + 3*lptr);
 	for (lptr=0; lptr<10; lptr++) areaclear (adapted, 0, 9 - lptr, 0, 0, 320, 1, 64 + surlight - lptr);
 	for (lptr=0; lptr<10; lptr++) areaclear (adapted, 0, 190 + lptr, 0, 0, 320, 1, 64 + surlight - lptr);
 	for (lptr=0; lptr<10; lptr++) areaclear (adapted, 9 - lptr, 10, 0, 0, 1, 180, 64 + surlight - lptr);

--- a/source/NOCTIS-0.CPP
+++ b/source/NOCTIS-0.CPP
@@ -5938,7 +5938,7 @@ void cupola (float y_or, float brk)
 					 +cupsize * clon * sin(lat),
 					 -cupheight * 	   cos(lat),
 					 +cupsize * slon * sin(lat),
-					 -50000, 10, 1, 0, 1, 1);
+					 -50000, 10, hud_closed, 0, 1, 1);
 			flares = 0;
 		}
 	}

--- a/source/NOCTIS-0.CPP
+++ b/source/NOCTIS-0.CPP
@@ -6138,14 +6138,13 @@ int  blnr;
 
 
 
-void surrounding (char compass_on, int openhudcount)
+void surrounding (char compass_on, int openhudcount_in)
 {
 	int	cpos, crem;
 	long	lsecs, lptr;
 	float	pp_delta, ccom;
 
-
-    for (lptr=0; lptr<04; lptr++) areaclear (adapted, 10, openhudcount + 9 - lptr, 0, 0, 300, 1, 54 + surlight + 3*lptr);
+    for (lptr=0; lptr<04; lptr++) areaclear (adapted, 10, openhudcount_in + 9 - lptr, 0, 0, 300, 1, 54 + surlight + 3*lptr);
 	for (lptr=0; lptr<10; lptr++) areaclear (adapted, 0, 9 - lptr, 0, 0, 320, 1, 64 + surlight - lptr);
 	for (lptr=0; lptr<10; lptr++) areaclear (adapted, 0, 190 + lptr, 0, 0, 320, 1, 64 + surlight - lptr);
 	for (lptr=0; lptr<10; lptr++) areaclear (adapted, 9 - lptr, 10, 0, 0, 1, 180, 64 + surlight - lptr);

--- a/source/NOCTIS-0.H
+++ b/source/NOCTIS-0.H
@@ -488,3 +488,7 @@ extern float	pp_pressure;
 extern float    pp_pulse;
 
 extern void additional_consumes (void);
+
+extern int openhudcount;
+extern int openhuddelta;
+extern char	hud_closed;

--- a/source/NOCTIS-0.H
+++ b/source/NOCTIS-0.H
@@ -161,7 +161,6 @@ extern char   surlight;
 extern Word old_currentbin_length;
 extern Dword   lastSnapshot;
 extern char   option_mouseLook;
-extern char   option_antialias_in_stardrifter;
 
 extern char   land_now;
 extern char   landing_point;

--- a/source/NOCTIS-0.H
+++ b/source/NOCTIS-0.H
@@ -488,7 +488,3 @@ extern float	pp_pressure;
 extern float    pp_pulse;
 
 extern void additional_consumes (void);
-
-extern int openhudcount;
-extern int openhuddelta;
-extern char	hud_closed;

--- a/source/NOCTIS-1.CPP
+++ b/source/NOCTIS-1.CPP
@@ -4943,20 +4943,6 @@ void planetary_main ()
 						goto nodissolve;
 					}
 				}
-                if (w == 9) { // Tab - Lens flare mode toggle
-					if (lens_flare_mode == 0) {
-						lens_flare_mode = 1;
-                        status("LENS FLARES ON", 50);
-					}
-                    else if (lens_flare_mode == 1) {
-                        lens_flare_mode = -1;
-                        status("LENS FLARES OFF", 50);
-                    }
-                    else {
-						lens_flare_mode = 0;
-                        status("VISOR LENS FLARES", 50);
-					}
-				}
 			}
 		}
 		endtype:

--- a/source/NOCTIS-1.CPP
+++ b/source/NOCTIS-1.CPP
@@ -4931,6 +4931,20 @@ void planetary_main ()
 						goto nodissolve;
 					}
 				}
+                if (w == 9) { // Tab - Lens flare mode toggle
+					if (lens_flare_mode == 0) {
+						lens_flare_mode = 1;
+                        status("FLARES ON", 50);
+					}
+                    else if (lens_flare_mode == 1) {
+                        lens_flare_mode = -1;
+                        status("FLARES OFF", 50);
+                    }
+                    else {
+						lens_flare_mode = 0;
+                        status("VISOR FLARES", 50);
+					}
+				}
 			}
 		}
 		endtype:

--- a/source/NOCTIS-1.CPP
+++ b/source/NOCTIS-1.CPP
@@ -4934,15 +4934,15 @@ void planetary_main ()
                 if (w == 9) { // Tab - Lens flare mode toggle
 					if (lens_flare_mode == 0) {
 						lens_flare_mode = 1;
-                        status("FLARES ON", 50);
+                        status("LENS FLARES ON", 50);
 					}
                     else if (lens_flare_mode == 1) {
                         lens_flare_mode = -1;
-                        status("FLARES OFF", 50);
+                        status("LENS FLARES OFF", 50);
                     }
                     else {
 						lens_flare_mode = 0;
-                        status("VISOR FLARES", 50);
+                        status("VISOR LENS FLARES", 50);
 					}
 				}
 			}

--- a/source/NOCTIS-1.CPP
+++ b/source/NOCTIS-1.CPP
@@ -3337,10 +3337,7 @@ void planetary_main ()
 	extern int moviedeck;
 	int movie_cutoff=0;
 	/*global*/opencapcount= 1;
-	int	 opencapdelta = 0;
-	int	 openhudcount = 180;
-	int	 openhuddelta = 0;
-	char	 hud_closed   = 1;
+	int	      opencapdelta = 0;
 	char	 widesnapping = 0;
 
 	int 	 w, lw = 10, now = 25, waveratio = 5, waveblur = 0;
@@ -3734,9 +3731,6 @@ void planetary_main ()
 			_read (sfh, &pos_z, 4);
 			_read (sfh, &user_alfa, 4);
 			_read (sfh, &user_beta, 4);
-			_read (sfh, &openhuddelta, 2);
-			_read (sfh, &openhudcount, 2);
-			_read (sfh, &hud_closed, 1);
 			_close (sfh);
 			landed = 1;
 			opencapdelta = 0;
@@ -4932,9 +4926,6 @@ void planetary_main ()
 						_write (sfh, &pos_z, 4);
 						_write (sfh, &user_alfa, 4);
 						_write (sfh, &user_beta, 4);
-						_write (sfh, &openhuddelta, 2);
-						_write (sfh, &openhudcount, 2);
-						_write (sfh, &hud_closed, 1);
 						_close (sfh);
 						exitflag = 1;
 						goto nodissolve;

--- a/source/NOCTIS-2.H
+++ b/source/NOCTIS-2.H
@@ -6,3 +6,6 @@ extern void ShowMovieSetup(int moviefsec, char movieflash, int moviedeck);
 extern void wrouthud (unsigned x, unsigned y, unsigned l, char *text);
 extern void FitOutHudBuffer(int min, int max);
 extern void ShowAboutPage(char surface);
+extern int openhudcount;
+extern int openhuddelta;
+extern char	hud_closed;

--- a/source/NOCTIS-2.H
+++ b/source/NOCTIS-2.H
@@ -6,6 +6,3 @@ extern void ShowMovieSetup(int moviefsec, char movieflash, int moviedeck);
 extern void wrouthud (unsigned x, unsigned y, unsigned l, char *text);
 extern void FitOutHudBuffer(int min, int max);
 extern void ShowAboutPage(char surface);
-extern int openhuddelta;
-extern int openhudcount;
-extern char hud_closed;

--- a/source/NOCTIS-2.H
+++ b/source/NOCTIS-2.H
@@ -9,3 +9,4 @@ extern void ShowAboutPage(char surface);
 extern int openhudcount;
 extern int openhuddelta;
 extern char	hud_closed;
+extern char lens_flare_mode;

--- a/source/NOCTIS-2.H
+++ b/source/NOCTIS-2.H
@@ -6,3 +6,6 @@ extern void ShowMovieSetup(int moviefsec, char movieflash, int moviedeck);
 extern void wrouthud (unsigned x, unsigned y, unsigned l, char *text);
 extern void FitOutHudBuffer(int min, int max);
 extern void ShowAboutPage(char surface);
+extern int openhuddelta;
+extern int openhudcount;
+extern char hud_closed;

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -460,6 +460,7 @@ void freeze ()
 	WRITEFILE (fh, &option_mouseLook, sizeof(option_mouseLook));				//40
 	WRITEFILE (fh, &roofspeed, sizeof(roofspeed));
 	WRITEFILE (fh, &hud_closed, sizeof(hud_closed));
+	WRITEFILE (fh, &lens_flare_mode, sizeof(lens_flare_mode));
 	_close (fh);
 }
 
@@ -1191,6 +1192,8 @@ char about = 0;
 int	openhudcount = 180;
 int	openhuddelta = 0;
 char hud_closed = 1;
+
+char lens_flare_mode = 0;
 
 unsigned char far * ctrlkeys     = (unsigned char far *) 0x00000417;
 
@@ -1992,6 +1995,7 @@ void unfreeze ()
 		READFILE (fh, &option_mouseLook, sizeof(option_mouseLook));				//40
 		READFILE (fh, &roofspeed, sizeof(roofspeed));
         READFILE (fh, &hud_closed, sizeof(hud_closed));
+        READFILE (fh, &lens_flare_mode, sizeof(lens_flare_mode));
 		strcpy(fcs_status_extended, fcs_status_extended);
 		_close (fh);
         
@@ -4377,6 +4381,20 @@ void main ()
 				if (c=='-' && surlight > 10 && !moviestat) surlight--;
 				//if (c=='+' && surlight < 63) surlight++;
 				//if (c=='-' && surlight > 10) surlight--;
+                if (c==9) { // Tab - Lens flare mode toggle
+					if (lens_flare_mode == 0) {
+						lens_flare_mode = 1;
+                        status("FLARES ON", 50);
+					}
+                    else if (lens_flare_mode == 1) {
+                        lens_flare_mode = -1;
+                        status("FLARES OFF", 50);
+                    }
+                    else {
+						lens_flare_mode = 0;
+                        status("VISOR FLARES", 50);
+					}
+				}
 			}
 	endmain: 
 		
@@ -4412,12 +4430,14 @@ void ShowAboutPage(char surface) {
 		wrouthud (14,71, NULL,   "M OR ASTERISK - SNAPSHOT                    N OR / - WIDE SNAPSHOT");
 		wrouthud (14,77, NULL,   "B OR DELETE - RAW SNAPSHOT");
 		wrouthud (14,83, NULL,   "F3 - MOVIEMAKER");
-		wrouthud (14,89, NULL,  "UP ARROW - TOGGLE MOUSELOOK");
+        wrouthud (14,89, NULL,  "TAB - TOGGLE LENS FLARES");
+		wrouthud (14,95, NULL,  "UP ARROW - TOGGLE MOUSELOOK");
 	} else {
 		wrouthud (14, 37, NULL, "SHORTCUT KEYS (WHEN IN SPACE):");
 		wrouthud (14, 53, NULL, "M OR ASTERISK - SNAPSHOT                     B - RAW SNAPSHOT");
 		wrouthud (14, 59, NULL, "F3 - MOVIEMAKER");
-		wrouthud (14, 65, NULL, "S - TOGGLE ROOFSPEED");
+		wrouthud (14, 65, NULL, "TAB - TOGGLE LENS FLARES");
+		wrouthud (14, 71, NULL, "S - TOGGLE ROOFSPEED");
 	}
 	areaclear (adapted, 11, 178, 310, 188, 0, 0, 72);
 	if (charge<0) {

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -460,7 +460,6 @@ void freeze ()
 	WRITEFILE (fh, &option_mouseLook, sizeof(option_mouseLook));				//40
 	WRITEFILE (fh, &roofspeed, sizeof(roofspeed));
 	WRITEFILE (fh, &hud_closed, sizeof(hud_closed));
-	WRITEFILE (fh, &lens_flare_mode, sizeof(lens_flare_mode));
 	_close (fh);
 }
 
@@ -1995,7 +1994,6 @@ void unfreeze ()
 		READFILE (fh, &option_mouseLook, sizeof(option_mouseLook));				//40
 		READFILE (fh, &roofspeed, sizeof(roofspeed));
         READFILE (fh, &hud_closed, sizeof(hud_closed));
-        READFILE (fh, &lens_flare_mode, sizeof(lens_flare_mode));
 		strcpy(fcs_status_extended, fcs_status_extended);
 		_close (fh);
         
@@ -4406,20 +4404,6 @@ void main ()
 				if (c=='-' && surlight > 10 && !moviestat) surlight--;
 				//if (c=='+' && surlight < 63) surlight++;
 				//if (c=='-' && surlight > 10) surlight--;
-                if (c==9) { // Tab - Lens flare mode toggle
-					if (lens_flare_mode == 0) {
-						lens_flare_mode = 1;
-                        status("FLARES ON", 50);
-					}
-                    else if (lens_flare_mode == 1) {
-                        lens_flare_mode = -1;
-                        status("FLARES OFF", 50);
-                    }
-                    else {
-						lens_flare_mode = 0;
-                        status("VISOR FLARES", 50);
-					}
-				}
 			}
 	endmain: 
 		
@@ -4455,15 +4439,13 @@ void ShowAboutPage(char surface) {
 		wrouthud (14,71, NULL,  "M OR ASTERISK - SNAPSHOT                    N OR / - WIDE SNAPSHOT");
 		wrouthud (14,77, NULL,  "B OR DELETE - RAW SNAPSHOT");
 		wrouthud (14,83, NULL,  "F3 - MOVIEMAKER");
-    wrouthud (14,89, NULL,  "TAB - TOGGLE LENS FLARES");
 		wrouthud (14,89, NULL,  "DOWN ARROW - TOGGLE MOUSELOOK");
 	} else {
 		wrouthud (14, 37, NULL, "SHORTCUT KEYS (WHEN IN SPACE):");
 		wrouthud (14, 53, NULL, "M OR ASTERISK - SNAPSHOT                    B - RAW SNAPSHOT");
 		wrouthud (14, 59, NULL, "F3 - MOVIEMAKER");
-		wrouthud (14, 65, NULL, "TAB - TOGGLE LENS FLARES");
 		wrouthud (14, 71, NULL, "S - TOGGLE ROOFSPEED");
-    wrouthud (14, 77, NULL, "DOWN ARROW - TOGGLE MOUSELOOK");
+        wrouthud (14, 77, NULL, "DOWN ARROW - TOGGLE MOUSELOOK");
 	}
 	areaclear (adapted, 11, 178, 310, 188, 0, 0, 72);
 	if (charge<0) {

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -2244,7 +2244,26 @@ void main ()
 
 	do {
 		sync_start ();
-		
+		/*
+        // effetto di apertura della visiera dell'HUD.
+		if (openhuddelta < 0) {
+			openhudcount += openhuddelta;
+			if (openhudcount <= 0) {
+				openhuddelta = 0;
+				openhudcount = 0;
+			}
+		}
+		// effetto di chiusura della visiera dell'HUD.
+		if (openhuddelta > 0) {
+			openhudcount += openhuddelta;
+			if (openhudcount >= 180) {
+				openhuddelta = 0;
+				openhudcount = 180;
+				hud_closed = 1;
+			}
+		}
+        */
+        
 		//
 		// Controllo del flag che indica quando ci si trova
 		// sulla "terrazza panoramica", il tetto dello stardrifter.
@@ -3902,6 +3921,15 @@ void main ()
 						about = 0;
 					}
 				}
+                if (c == 0x49) {
+					openhuddelta = -5;
+					hud_closed = 0;
+                    //option_antialias_in_stardrifter = 0;
+				}
+				if (c == 0x51) {
+					openhuddelta = +5;
+                    //option_antialias_in_stardrifter = 1;
+                }
 				if (c==0x3D){								// f3 - moviestat
 					if (moviestat == 0){
 						moviestat = 1;

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -92,7 +92,7 @@ void alogena ()
 	}
 
 	if (ilightv==1 && !elight)
-		lens_flares_for (cam_x, cam_y, cam_z, -10, 10, -10, -50000, 2, 1, 0, 1, 1);
+		lens_flares_for (cam_x, cam_y, cam_z, -10, 10, -10, -50000, 2, hud_closed, 0, 1, 1);
 }
 
 /* Quadranti di selezione del computer di bordo. */
@@ -1166,10 +1166,10 @@ void other_vehicle_at (double ovhx, double ovhy, double ovhz)
 	resetfx ();
 	cam_z -= 3100;
 
-	lens_flares_for (cam_x, cam_y, cam_z, 3225, 0, 0, -5e5, 3, 1, 1, 1, 1);
-	lens_flares_for (cam_x, cam_y, cam_z, -3225, 0, 0, -5e5, 3, 1, 1, 1, 1);
-	lens_flares_for (cam_x, cam_y, cam_z, 3225, 0, -6150, -5e5, 3, 1, 1, 1, 1);
-	lens_flares_for (cam_x, cam_y, cam_z, -3225, 0, -6150, -5e5, 3, 1, 1, 1, 1);
+	lens_flares_for (cam_x, cam_y, cam_z, 3225, 0, 0, -5e5, 3, hud_closed, 1, 1, 1);
+	lens_flares_for (cam_x, cam_y, cam_z, -3225, 0, 0, -5e5, 3, hud_closed, 1, 1, 1);
+	lens_flares_for (cam_x, cam_y, cam_z, 3225, 0, -6150, -5e5, 3, hud_closed, 1, 1, 1);
+	lens_flares_for (cam_x, cam_y, cam_z, -3225, 0, -6150, -5e5, 3, hud_closed, 1, 1, 1);
 }
 
 
@@ -2531,7 +2531,7 @@ void main ()
 				if (p_dsd>5*nearstar_p_ray[ir]&&p_dsd<1000*nearstar_p_ray[ir])
 					lens_flares_for (dzat_x, dzat_y, dzat_z, plx, ply, plz,
 							(10 * nearstar_p_ray[ir]) / p_dsd,
-							1 + (0.001 * p_dsd), 1, 0, 3, 0);
+							1 + (0.001 * p_dsd), hud_closed, 0, 3, 0);
 			}
 		}
 		if (l_dsd > 6 * nearstar_ray) {
@@ -2540,7 +2540,7 @@ void main ()
 					if (l_dsd>5*nearstar_ray&&l_dsd<1000*nearstar_ray) {
 						lens_flares_for (dzat_x, dzat_y, dzat_z,
 								 nearstar_x, nearstar_y, nearstar_z,
-								 (10 * nearstar_ray) / l_dsd, 1 + (0.001 * l_dsd), 1, 0, 3, 0);
+								 (10 * nearstar_ray) / l_dsd, 1 + (0.001 * l_dsd), hud_closed, 0, 3, 0);
 					}
 				}
 			}

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -459,6 +459,9 @@ void freeze ()
 	WRITEFILE (fh, &lastSnapshot, sizeof(lastSnapshot));				//36
 	WRITEFILE (fh, &option_mouseLook, sizeof(option_mouseLook));				//40
 	WRITEFILE (fh, &roofspeed, sizeof(roofspeed));
+	WRITEFILE (fh, &openhudcount, sizeof(openhudcount));
+	WRITEFILE (fh, &openhuddelta, sizeof(openhuddelta));
+	WRITEFILE (fh, &hud_closed, sizeof(hud_closed));
 	_close (fh);
 }
 
@@ -1186,6 +1189,10 @@ extern int moviedeck;
 int moviepaused=0;
 
 char about = 0;
+
+int	openhudcount = 180;
+int	openhuddelta = 0;
+char hud_closed = 1;
 
 unsigned char far * ctrlkeys     = (unsigned char far *) 0x00000417;
 
@@ -1986,6 +1993,9 @@ void unfreeze ()
 		READFILE (fh, &lastSnapshot, sizeof(lastSnapshot));				//36
 		READFILE (fh, &option_mouseLook, sizeof(option_mouseLook));				//40
 		READFILE (fh, &roofspeed, sizeof(roofspeed));
+        READFILE (fh, &openhudcount, sizeof(openhudcount));
+        READFILE (fh, &openhuddelta, sizeof(openhuddelta));
+        READFILE (fh, &hud_closed, sizeof(hud_closed));
 		strcpy(fcs_status_extended, fcs_status_extended);
 		_close (fh);
 	}
@@ -2242,26 +2252,6 @@ void main ()
 
 	do {
 		sync_start ();
-		/*
-        // effetto di apertura della visiera dell'HUD.
-		if (openhuddelta < 0) {
-			openhudcount += openhuddelta;
-			if (openhudcount <= 0) {
-				openhuddelta = 0;
-				openhudcount = 0;
-			}
-		}
-		// effetto di chiusura della visiera dell'HUD.
-		if (openhuddelta > 0) {
-			openhudcount += openhuddelta;
-			if (openhudcount >= 180) {
-				openhuddelta = 0;
-				openhudcount = 180;
-				hud_closed = 1;
-			}
-		}
-        */
-        
 		//
 		// Controllo del flag che indica quando ci si trova
 		// sulla "terrazza panoramica", il tetto dello stardrifter.
@@ -2947,10 +2937,13 @@ void main ()
 		// straordinariamente belli su uno schermo che, di per s�,
 		// � poco risolutivo, sia fisicamente che cromaticamente.
 		//
-        QUADWORDS -= 240;
-        psmooth_64 (adapted, 200);
-        psmooth_64 (adapted, 200);
-        QUADWORDS += 240;
+        pqw = QUADWORDS;
+        QUADWORDS = 160 + openhudcount * 80;
+        psmooth_64 (adapted, 160);
+        psmooth_64 (adapted, 160);
+        QUADWORDS = pqw;
+    
+        
 		//
 		// Tracciamento di tutte le stelle visibili.
 		//
@@ -3543,7 +3536,7 @@ void main ()
 		// disegna i bordi dello scafandro, illuminati in relazione
 		// all'ambiente circostante.
 		//
-		surrounding (0, 180);
+		surrounding (0, openhudcount);
 		// riduzione stanchezza (continua, eventualmente
 		// dall'ultima volta che si � scesi in superficie)
 		// e variazioni nelle pulsazioni, pi� verosimili...
@@ -3586,6 +3579,23 @@ void main ()
 				resolve = 0;
 				_delay = 13; // solo al ritorno da superficie
 				goto resynctoplanet;
+			}
+		}
+        // effetto di apertura della visiera dell'HUD.
+		if (openhuddelta < 0) {
+			openhudcount += openhuddelta;
+			if (openhudcount <= 0) {
+				openhuddelta = 0;
+				openhudcount = 0;
+			}
+		}
+		// effetto di chiusura della visiera dell'HUD.
+		if (openhuddelta > 0) {
+			openhudcount += openhuddelta;
+			if (openhudcount >= 180) {
+				openhuddelta = 0;
+				openhudcount = 180;
+				hud_closed = 1;
 			}
 		}
 		//
@@ -3917,15 +3927,13 @@ void main ()
 						about = 0;
 					}
 				}
-                /*
-                if (c == 0x49) {
+                if (c == 0x49) { // Page Up - Open visor
 					openhuddelta = -5;
 					hud_closed = 0;
 				}
-				if (c == 0x51) {
+				if (c == 0x51) { // Page Down - Close visor
 					openhuddelta = +5;
                 }
-                */
 				if (c==0x3D){								// f3 - moviestat
 					if (moviestat == 0){
 						moviestat = 1;

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -2256,7 +2256,7 @@ void main ()
 
 	do {
 		sync_start ();
-        
+		
 		//
 		// Controllo del flag che indica quando ci si trova
 		// sulla "terrazza panoramica", il tetto dello stardrifter.

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -2256,6 +2256,7 @@ void main ()
 
 	do {
 		sync_start ();
+        
 		//
 		// Controllo del flag che indica quando ci si trova
 		// sulla "terrazza panoramica", il tetto dello stardrifter.

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -459,7 +459,6 @@ void freeze ()
 	WRITEFILE (fh, &lastSnapshot, sizeof(lastSnapshot));				//36
 	WRITEFILE (fh, &option_mouseLook, sizeof(option_mouseLook));				//40
 	WRITEFILE (fh, &roofspeed, sizeof(roofspeed));
-	WRITEFILE (fh, &option_antialias_in_stardrifter, sizeof(option_antialias_in_stardrifter));
 	_close (fh);
 }
 
@@ -1987,7 +1986,6 @@ void unfreeze ()
 		READFILE (fh, &lastSnapshot, sizeof(lastSnapshot));				//36
 		READFILE (fh, &option_mouseLook, sizeof(option_mouseLook));				//40
 		READFILE (fh, &roofspeed, sizeof(roofspeed));
-		READFILE (fh, &option_antialias_in_stardrifter, sizeof(option_antialias_in_stardrifter));
 		strcpy(fcs_status_extended, fcs_status_extended);
 		_close (fh);
 	}
@@ -2949,12 +2947,10 @@ void main ()
 		// straordinariamente belli su uno schermo che, di per s�,
 		// � poco risolutivo, sia fisicamente che cromaticamente.
 		//
-		if (option_antialias_in_stardrifter){
-			QUADWORDS -= 240;
-			psmooth_64 (adapted, 200);
-			psmooth_64 (adapted, 200);
-			QUADWORDS += 240;
-		}
+        QUADWORDS -= 240;
+        psmooth_64 (adapted, 200);
+        psmooth_64 (adapted, 200);
+        QUADWORDS += 240;
 		//
 		// Tracciamento di tutte le stelle visibili.
 		//
@@ -3921,15 +3917,15 @@ void main ()
 						about = 0;
 					}
 				}
+                /*
                 if (c == 0x49) {
-					//openhuddelta = -5;
-					//hud_closed = 0;
-                    option_antialias_in_stardrifter = 0;
+					openhuddelta = -5;
+					hud_closed = 0;
 				}
 				if (c == 0x51) {
-					//openhuddelta = +5;
-                    option_antialias_in_stardrifter = 1;
+					openhuddelta = +5;
                 }
+                */
 				if (c==0x3D){								// f3 - moviestat
 					if (moviestat == 0){
 						moviestat = 1;
@@ -4371,13 +4367,6 @@ void main ()
 				if (c=='-' && surlight > 10 && !moviestat) surlight--;
 				//if (c=='+' && surlight < 63) surlight++;
 				//if (c=='-' && surlight > 10) surlight--;
-				if (c==9) {								// TAB - antialiasing on/off
-					if (option_antialias_in_stardrifter == 0) {
-						option_antialias_in_stardrifter = 1;
-					} else {
-						option_antialias_in_stardrifter = 0;
-					}
-				}
 			}
 	endmain: 
 		
@@ -4418,8 +4407,7 @@ void ShowAboutPage(char surface) {
 		wrouthud (14, 37, NULL, "SHORTCUT KEYS (WHEN IN SPACE):");
 		wrouthud (14, 53, NULL, "M OR ASTERISK - SNAPSHOT                     B - RAW SNAPSHOT");
 		wrouthud (14, 59, NULL, "F3 - MOVIEMAKER");
-		wrouthud (14, 65, NULL, "TAB - TOGGLE ANTIALIASING");
-		wrouthud (14, 71, NULL, "S - TOGGLE ROOFSPEED");
+		wrouthud (14, 65, NULL, "S - TOGGLE ROOFSPEED");
 	}
 	areaclear (adapted, 11, 178, 310, 188, 0, 0, 72);
 	if (charge<0) {

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -459,8 +459,6 @@ void freeze ()
 	WRITEFILE (fh, &lastSnapshot, sizeof(lastSnapshot));				//36
 	WRITEFILE (fh, &option_mouseLook, sizeof(option_mouseLook));				//40
 	WRITEFILE (fh, &roofspeed, sizeof(roofspeed));
-	WRITEFILE (fh, &openhudcount, sizeof(openhudcount));
-	WRITEFILE (fh, &openhuddelta, sizeof(openhuddelta));
 	WRITEFILE (fh, &hud_closed, sizeof(hud_closed));
 	_close (fh);
 }
@@ -1993,11 +1991,15 @@ void unfreeze ()
 		READFILE (fh, &lastSnapshot, sizeof(lastSnapshot));				//36
 		READFILE (fh, &option_mouseLook, sizeof(option_mouseLook));				//40
 		READFILE (fh, &roofspeed, sizeof(roofspeed));
-        READFILE (fh, &openhudcount, sizeof(openhudcount));
-        READFILE (fh, &openhuddelta, sizeof(openhuddelta));
         READFILE (fh, &hud_closed, sizeof(hud_closed));
 		strcpy(fcs_status_extended, fcs_status_extended);
 		_close (fh);
+        
+        if (hud_closed == 1) {
+            openhudcount = 180;
+        } else {
+            openhudcount = 0;
+        }
 	}
 	else
 		return;

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -3922,13 +3922,13 @@ void main ()
 					}
 				}
                 if (c == 0x49) {
-					openhuddelta = -5;
-					hud_closed = 0;
-                    //option_antialias_in_stardrifter = 0;
+					//openhuddelta = -5;
+					//hud_closed = 0;
+                    option_antialias_in_stardrifter = 0;
 				}
 				if (c == 0x51) {
-					openhuddelta = +5;
-                    //option_antialias_in_stardrifter = 1;
+					//openhuddelta = +5;
+                    option_antialias_in_stardrifter = 1;
                 }
 				if (c==0x3D){								// f3 - moviestat
 					if (moviestat == 0){

--- a/source/NOCTIS.CPP
+++ b/source/NOCTIS.CPP
@@ -4425,16 +4425,16 @@ void ShowAboutPage(char surface) {
 	if (surface) {
 		wrouthud (14, 37, NULL, "SURFACE SHORTCUT KEYS:");
 		wrouthud (14,53, NULL,  "0-9 - MOVEMENT SPEED");
-		wrouthud (14,59, NULL,   "J - JUMP                                    L - LAND ON SURFACE");
-		wrouthud (14,65, NULL,   "SPACE - JETPACK                             C - DISENGAGE JETPACK CONTROL");
-		wrouthud (14,71, NULL,   "M OR ASTERISK - SNAPSHOT                    N OR / - WIDE SNAPSHOT");
-		wrouthud (14,77, NULL,   "B OR DELETE - RAW SNAPSHOT");
-		wrouthud (14,83, NULL,   "F3 - MOVIEMAKER");
+		wrouthud (14,59, NULL,  "J - JUMP                                    L - LAND ON SURFACE");
+		wrouthud (14,65, NULL,  "SPACE - JETPACK                             C - DISENGAGE JETPACK CONTROL");
+		wrouthud (14,71, NULL,  "M OR ASTERISK - SNAPSHOT                    N OR / - WIDE SNAPSHOT");
+		wrouthud (14,77, NULL,  "B OR DELETE - RAW SNAPSHOT");
+		wrouthud (14,83, NULL,  "F3 - MOVIEMAKER");
         wrouthud (14,89, NULL,  "TAB - TOGGLE LENS FLARES");
 		wrouthud (14,95, NULL,  "UP ARROW - TOGGLE MOUSELOOK");
 	} else {
 		wrouthud (14, 37, NULL, "SHORTCUT KEYS (WHEN IN SPACE):");
-		wrouthud (14, 53, NULL, "M OR ASTERISK - SNAPSHOT                     B - RAW SNAPSHOT");
+		wrouthud (14, 53, NULL, "M OR ASTERISK - SNAPSHOT                    B - RAW SNAPSHOT");
 		wrouthud (14, 59, NULL, "F3 - MOVIEMAKER");
 		wrouthud (14, 65, NULL, "TAB - TOGGLE LENS FLARES");
 		wrouthud (14, 71, NULL, "S - TOGGLE ROOFSPEED");


### PR DESCRIPTION
- Removed all functionality related to `TAB` to toggle antialiasing in the stardrifter
- Implemented the visor effect when in space (`Page Up` and `Page Down`, just like on the surface)
- Made the visor variables global and stored in game freeze states
- Updated all lens flares to only appear when the visor is on (vanilla behavior when on the surface)