### PR TITLE
Added link to a hosted manual with fixes for modern browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the home of Noctis IV Plus, a basic modification of Alessandro Ghignola'
 
 ![](gallery/SAMPLE.BMP)
 
-For a list of changes, see [source/NIVPLUS_CHANGES.TXT](source/NIVPLUS_CHANGES.TXT)
+For a list of changes, see [source/docs/NIVPLUS_CHANGES.TXT](source/docs/NIVPLUS_CHANGES.TXT)
 
 For the manual, see [manual/noctis_iv_manual.html](manual/noctis_iv_manual.html)
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ For a list of changes, see [source/NIVPLUS_CHANGES.TXT](source/NIVPLUS_CHANGES.T
 
 For the manual, see [manual/noctis_iv_manual.html](manual/noctis_iv_manual.html)
 
+To read the manual online, visit [https://nimaid.github.io/noctisiv/](https://nimaid.github.io/noctisiv/)
+
 ## Getting Noctis IV Plus to run on modern computers
 
 Noctis IV was made for MS-DOS and early Windows versions that still supported 16-bit MS-DOS executables natively, and as such, you'll need to be able to run DOS on your computer. To run Noctis IV plus on modern computers, you have three main options, in order of simplest to most complicated to setup:


### PR DESCRIPTION
This adds a link to the classic Noctis IV manual, hosted with GitHub Pages. It has the following fixes applied to allow it to work with modern browsers, in addition to updated links, as described in #20.